### PR TITLE
Response codes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'eclipse'
 apply plugin: 'osgi'
 
 group = 'net.whistlingfish'
-version = '1.0.3'
+version = '1.0.4'
 
 sourceCompatibility = 1.7
 

--- a/src/main/java/net/whistlingfish/harmony/protocol/OAReplyParser.java
+++ b/src/main/java/net/whistlingfish/harmony/protocol/OAReplyParser.java
@@ -16,6 +16,8 @@ public abstract class OAReplyParser {
 	 static {
 		 validResponses.add("100");
 		 validResponses.add("200");
+		 validResponses.add("506"); //bluetooth not connected 
+		 validResponses.add("566"); //Command not found for device, recoverable
 	 }
 	    
     public abstract IQ parseReplyContents(String statusCode, String errorString, String contents);


### PR DESCRIPTION
Hey @tuck182 !  I have run into an issue where the Harmony hub responds to commands with some "500" errors if something is not right on its end.  These do not actually mean anything is wrong on the client side and can be safely ignored.  I added the ones I know about to the Acceptable types list as I don't know what the valid range might be.  Thoughts?  
