### PR TITLE
Fixes #19 and adds state digest support

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,0 @@
-Implement state digest:
-<iq id="x0M38-161" from="7b1466ad-1e7f-440f-1e4b-c1f74883096e" type="get"><oa xmlns='connect.logitech.com' mime='connect.statedigest?get'></oa></iq>
-<iq id="x0M38-161" to="7b1466ad-1e7f-440f-1e4b-c1f74883096e" type="get"><oa xmlns='connect.logitech.com' mime='connect.statedigest?get' errorcode='200' errorstring='OK'><![CDATA[sleepTimerId=-1:configVersion=107:contentVersion=79:activityId=7663318:mode=3:discoveryServer=http://svcs.myharmony.com/Discovery/Discovery.svc:wifiStatus=1:activityStatus=2:syncStatus=0:updates=table: 0x4f2ab8:stateVersion=63:hubSwVersion=3.7.37:hubUpdate=true:sequence=false:accountId=4495137]]></oa></iq>

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-core:2.8.7'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.7'
     compile 'org.slf4j:slf4j-api:1.7.24'
+    compile 'com.google.code.gson:gson:2.5'
     provided 'ch.qos.logback:logback-core:1.2.1'
     provided 'ch.qos.logback:logback-classic:1.2.1'
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
             <version>2.33</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.martiansoftware</groupId>
             <artifactId>jsap</artifactId>
             <version>2.1</version>

--- a/src/main/java/net/whistlingfish/harmony/ActivityStatusListener.java
+++ b/src/main/java/net/whistlingfish/harmony/ActivityStatusListener.java
@@ -1,0 +1,18 @@
+package net.whistlingfish.harmony;
+
+import net.whistlingfish.harmony.config.Activity;
+import net.whistlingfish.harmony.config.Activity.Status;
+
+public abstract class ActivityStatusListener implements HarmonyHubListener {  
+    public abstract void activityStatusChanged(Activity activity, Status status);
+
+    @Override
+    public void addTo(HarmonyClient harmonyClient) {
+        harmonyClient.addListener(this);
+    }
+
+    @Override
+    public void removeFrom(HarmonyClient harmonyClient) {
+        harmonyClient.removeListener(this);
+    }
+}

--- a/src/main/java/net/whistlingfish/harmony/HarmonyClient.java
+++ b/src/main/java/net/whistlingfish/harmony/HarmonyClient.java
@@ -366,8 +366,10 @@ public class HarmonyClient {
         if (getConfig().getActivityById(activityId) == null) {
             throw new IllegalArgumentException(format("Unknown activity '%d'", activityId));
         }
-        sendOAStanza(connection, new StartActivityRequest(activityId), StartActivityReply.class,
-                START_ACTIVITY_REPLY_TIMEOUT);
+        if (currentActivity == null || currentActivity.getId() != activityId) {
+        	sendOAStanza(connection, new StartActivityRequest(activityId), StartActivityReply.class,
+        			START_ACTIVITY_REPLY_TIMEOUT);
+        }
     }
 
     public void startActivityByName(String label) {
@@ -375,6 +377,8 @@ public class HarmonyClient {
         if (activity == null) {
             throw new IllegalArgumentException(format("Unknown activity '%s'", label));
         }
-        startActivity(activity.getId());
+        if (currentActivity == null || !label.equals(currentActivity.getLabel())) {
+        	startActivity(activity.getId());
+        }
     }
 }

--- a/src/main/java/net/whistlingfish/harmony/Main.java
+++ b/src/main/java/net/whistlingfish/harmony/Main.java
@@ -14,6 +14,7 @@ import com.google.inject.Injector;
 import com.martiansoftware.jsap.CommandLineTokenizer;
 
 import net.whistlingfish.harmony.config.Activity;
+import net.whistlingfish.harmony.config.Activity.Status;
 import net.whistlingfish.harmony.shell.ShellCommandWrapper;
 
 public class Main {
@@ -32,6 +33,13 @@ public class Main {
             @Override
             public void activityStarted(Activity activity) {
                 System.out.println(format("activity changed: [%d] %s", activity.getId(), activity.getLabel()));
+            }
+        });
+        harmonyClient.addListener(new ActivityStatusListener() {
+            @Override
+            public void activityStatusChanged(Activity activity, Status status) {
+                System.out.println(format("activity status changed: [%d] %s - %s", activity.getId(), 
+                        activity.getLabel(), status.toString()));               
             }
         });
         harmonyClient.connect(args[0]);

--- a/src/main/java/net/whistlingfish/harmony/config/Activity.java
+++ b/src/main/java/net/whistlingfish/harmony/config/Activity.java
@@ -1,14 +1,13 @@
 package net.whistlingfish.harmony.config;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
+import static java.lang.String.format;
+
 import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import static java.lang.String.format;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
 
 public class Activity {
     private String label;
@@ -23,6 +22,23 @@ public class Activity {
     private String type;
     private String icon;
     private String baseImageUri;
+    private Status status;
+    
+    public enum Status {
+    	HUB_IS_OFF,
+    	ACTIVITY_IS_STARTING,
+    	ACTIVITY_IS_STARTED,
+    	HUB_IS_TURNING_OFF,
+    	UNKNOWN
+    }
+    
+    public Status getStatus() {
+    	return status;
+    }
+    
+    public void setStatus(Status status) {
+        this.status = status;
+    }
 
     public String getLabel() {
         return label;

--- a/src/main/java/net/whistlingfish/harmony/protocol/EventStanza.java
+++ b/src/main/java/net/whistlingfish/harmony/protocol/EventStanza.java
@@ -1,0 +1,123 @@
+package net.whistlingfish.harmony.protocol;
+
+import static net.whistlingfish.harmony.Jackson.OBJECT_MAPPER;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.StandardExtensionElement;
+import org.jivesoftware.smack.packet.Stanza;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+import net.whistlingfish.harmony.config.Activity.Status;
+
+public class EventStanza  {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventStanza.class);
+
+    // JSON tokens to parse events
+    private String errorCode;
+    private String activityId;
+    private Integer activityStatus;
+    
+    private EventType eventType;
+    private static final Gson gson = new Gson();
+    
+    public enum EventType {
+        STATE_DIGEST,
+        START_ACTIVITY_FINISHED,
+    }
+    
+    private EventStanza() {
+    }
+    
+    public Integer getActivityId() {
+        if (activityId != null) {
+            try {
+                Integer id = Integer.parseInt(activityId);
+                return id;
+            } catch (NumberFormatException e)
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+    
+    public Status getActivityStatus() {
+        if (activityStatus != null) {
+            switch (activityStatus)
+            {  
+                case 0: 
+                    return Status.HUB_IS_OFF;
+                case 1:
+                    return Status.ACTIVITY_IS_STARTING;
+                case 2:
+                    return Status.ACTIVITY_IS_STARTED;
+                case 3:
+                    return Status.HUB_IS_TURNING_OFF;
+            }
+        }
+        return Status.UNKNOWN;
+    }
+    
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public int getErrorCode() {
+        if (errorCode != null) {
+            try {
+                return Integer.parseInt(errorCode);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
+    public static EventStanza create(Stanza stanza) {
+        if (!(stanza instanceof Message)) {
+            return null;
+        }
+        Message message = (Message) stanza;
+        ExtensionElement element = message.getExtension("event", "connect.logitech.com");
+        if (element == null || !(element instanceof StandardExtensionElement)) {
+            return null;
+        }
+        StandardExtensionElement stdElement = (StandardExtensionElement) element;
+        String type = stdElement.getAttributeValue("type");
+        String content = stdElement.getText();
+
+        if (type != null && type.equals("connect.stateDigest?notify"))
+        {
+            if (content != null) {
+                try {
+                    EventStanza event;
+                    synchronized(gson) {
+                        event = gson.fromJson(content, EventStanza.class);
+                    }
+                    event.eventType = EventType.STATE_DIGEST;
+                    return event;
+                } catch (JsonSyntaxException e) {
+                    logger.debug("Exception parsing stateDigest: {}", e.getMessage());
+                }
+            }
+        } else if (type.equals("harmony.engine?startActivityFinished")) {
+            if (content != null) {
+                try {
+                    EventStanza event = OBJECT_MAPPER.convertValue(OAReplyParser.parseKeyValuePairs(null, null, content), 
+                            EventStanza.class);
+                    event.eventType = EventType.START_ACTIVITY_FINISHED;
+                    return event;
+                } catch (IllegalArgumentException e) {
+                    logger.debug("Exception parsing startActivityFinished: {}", e.getMessage());
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/whistlingfish/harmony/protocol/OAReplyParser.java
+++ b/src/main/java/net/whistlingfish/harmony/protocol/OAReplyParser.java
@@ -28,10 +28,14 @@ public abstract class OAReplyParser {
      */
     static final Pattern kvRE = Pattern.compile("(.*?)=(.*)");
 
-    protected Map<String, Object> parseKeyValuePairs(String statusCode, String errorString, String contents) {
+    protected static Map<String, Object> parseKeyValuePairs(String statusCode, String errorString, String contents) {
         Map<String, Object> params = new HashMap<>();
-        params.put("statusCode", statusCode);
-        params.put("errorString", errorString);
+        if (statusCode != null) {
+            params.put("statusCode", statusCode);
+        }
+        if (errorString != null) {
+            params.put("errorString", errorString);
+        }
         for (String pair : contents.split(":")) {
             Matcher matcher = kvRE.matcher(pair);
             if (!matcher.matches()) {
@@ -51,7 +55,7 @@ public abstract class OAReplyParser {
         return params;
     }
 
-    protected Map<String, Object> parsePseudoJson(String value) {
+    protected static Map<String, Object> parsePseudoJson(String value) {
         Map<String, Object> params = new HashMap<>();
         value = value.substring(1, value.length() - 1);
         for (String pair : value.split(", ?")) {
@@ -64,7 +68,7 @@ public abstract class OAReplyParser {
         return params;
     }
 
-    private Object parsePseudoJsonValue(String value) {
+    private static Object parsePseudoJsonValue(String value) {
         switch (value.charAt(0)) {
             case '{':
                 return parsePseudoJsonValue(value);


### PR DESCRIPTION
Sorry, I screwed with not creating a new branch for my second commit, so there are two features sitting on this PR.

Issue 1
For original issue please see openhab/openhab2-addons#2497 and recommendation to fix it in this library in openhab/openhab2-addons#2634. 

I have one concern to discuss - when connection is lost with the hub and later it is reconnected, when during the disconnection period activity changes on the hub, it seems to be not updated after the reconnection. This causes that current activity is not always up to date. Should we add force update of the current activity upon reconnection? If yes, which point is best?

Issue 2
Added state digest support:
  * a new listener class to provide backwards compatibility.
  * GSON library to parse events (this is real JSON), unfortunately in OA stanza replies there is no real JSON, so GSON can't be used there
  * corrected passing activity finished events
  * general methods for parsing pseudo-json and comma-separated messages made static to make them generic utility functions

Thanks
Pawel 

Signed-off-by: Pawel Pieczul <pieczul@gmail.com> (github: ppieczul)