### PR TITLE
Fixing a case where on some hubs the state digest events do not contain error code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'eclipse'
 apply plugin: 'osgi'
 
 group = 'net.whistlingfish'
-version = '1.2.1'
+version = '1.2.2'
 
 sourceCompatibility = 1.7
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.whistlingfish</groupId>
     <artifactId>harmony-java-client</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/src/main/java/net/whistlingfish/harmony/protocol/EventStanza.java
+++ b/src/main/java/net/whistlingfish/harmony/protocol/EventStanza.java
@@ -94,7 +94,12 @@ public class EventStanza  {
         {
             if (content != null) {
                 try {
+                    logger.debug("stateDigest notify content: {}", content);
                     EventStanza event = OBJECT_MAPPER.readValue(content, EventStanza.class);
+                    // if error code is ommitted in the stanza, we assume it was successful
+                    if (event.errorCode == null) {
+                        event.errorCode = "200";
+                    }
                     event.eventType = EventType.STATE_DIGEST;
                     return event;
                 } catch (IOException e) {


### PR DESCRIPTION
When they are successful, the error code is omitted. Such events are discarded today, because error code = 200 is expected.

See: https://community.openhab.org/t/harmony-hub-activitystarting/34596