### PR TITLE
Fixing a case where on some hubs the state digest events do not conta…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'eclipse'
 apply plugin: 'osgi'
 
 group = 'net.whistlingfish'
-version = '1.2.1'
+version = '1.2.2'
 
 sourceCompatibility = 1.7
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.whistlingfish</groupId>
     <artifactId>harmony-java-client</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/src/main/java/net/whistlingfish/harmony/config/Activity.java
+++ b/src/main/java/net/whistlingfish/harmony/config/Activity.java
@@ -22,7 +22,7 @@ public class Activity {
     private String type;
     private String icon;
     private String baseImageUri;
-    private Status status;
+    private Status status = Status.UNKNOWN;
     
     public enum Status {
     	HUB_IS_OFF,

--- a/src/main/java/net/whistlingfish/harmony/protocol/EventStanza.java
+++ b/src/main/java/net/whistlingfish/harmony/protocol/EventStanza.java
@@ -94,7 +94,12 @@ public class EventStanza  {
         {
             if (content != null) {
                 try {
+                    logger.debug("stateDigest notify content: {}", content);
                     EventStanza event = OBJECT_MAPPER.readValue(content, EventStanza.class);
+                    // if error code is ommitted in the stanza, we assume it was successful
+                    if (event.errorCode == null) {
+                        event.errorCode = "200";
+                    }
                     event.eventType = EventType.STATE_DIGEST;
                     return event;
                 } catch (IOException e) {


### PR DESCRIPTION
…in error code parameter when they are successful.

See: https://community.openhab.org/t/harmony-hub-activitystarting/34596

Fixing a case where PowerOff activity finished state digest was not always passed to the listeners.

